### PR TITLE
feat: Add `rkyv` `Serialize`, `Deserialize`, `Archive`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,10 +38,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytecheck"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50690fb3370fb9fe3550372746084c46f2ac8c9685c583d2be10eefd89d3d1a3"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+ "rancor",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efb7846e0cb180355c2dec69e721edafa36919850f1a9f52ffba4ebc0393cb71"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "bytes"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cfg-if"
@@ -163,6 +192,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
+name = "hashbrown"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -175,7 +210,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93ead53efc7ea8ed3cfb0c79fc8023fbb782a5432b52830b6518941cebe6505c"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -199,6 +234,7 @@ version = "0.2.5"
 dependencies = [
  "ff",
  "hex",
+ "rkyv",
  "serde",
  "serde_arrays",
  "serde_derive",
@@ -219,6 +255,26 @@ name = "libc"
 version = "0.2.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
+
+[[package]]
+name = "munge"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0091202c98cf06da46c279fdf50cccb6b1c43b4521abdf6a27b4c7e71d5d9d7"
+dependencies = [
+ "munge_macro",
+]
+
+[[package]]
+name = "munge_macro"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "734799cf91479720b2f970c61a22850940dd91e27d4f02b1c6fc792778df2459"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
 
 [[package]]
 name = "num-bigint"
@@ -411,12 +467,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "ptr_meta"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe9e76f66d3f9606f44e45598d155cb13ecf09f4a28199e48daf8c8fc937ea90"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca414edb151b4c8d125c12566ab0d74dc9cdba36fb80eb7b848c15f495fd32d1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rancor"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf5f7161924b9d1cea0e4cabc97c372cea92b5f927fc13c6bca67157a0ad947"
+dependencies = [
+ "ptr_meta",
 ]
 
 [[package]]
@@ -447,6 +532,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "rend"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a35e8a6bf28cd121053a66aa2e6a2e3eaffad4a60012179f0e864aa5ffeff215"
+dependencies = [
+ "bytecheck",
+]
+
+[[package]]
+name = "rkyv"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e147371c75553e1e2fcdb483944a8540b8438c31426279553b9a8182a9b7b65"
+dependencies = [
+ "bytecheck",
+ "bytes",
+ "hashbrown 0.15.2",
+ "indexmap",
+ "munge",
+ "ptr_meta",
+ "rancor",
+ "rend",
+ "rkyv_derive",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "246b40ac189af6c675d124b802e8ef6d5246c53e17367ce9501f8f66a81abb7a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -507,6 +631,12 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "sp1-lib"
@@ -587,6 +717,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tracing"
 version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -634,6 +779,12 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "uuid"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,9 @@ bls12_381 = { version = "=0.8.0-sp1-4.0.0-v2", package = "sp1_bls12_381", defaul
 sha2 = { version = "0.10.8", default-features = false }
 ff = { version = "0.13.0", default-features = false, features = ["derive"] }
 spin = { version = "0.9.8", default-features = false, features = ["once"] }
-serde = { version = "^1.0", default-features = false, features = ["derive"], optional = true }
+serde = { version = "^1.0", default-features = false, features = [
+    "derive",
+], optional = true }
 serde_arrays = "0.2.0"
 rkyv = { version = "0.8.10", optional = true }
 
@@ -37,6 +39,5 @@ bls12_381 = { version = "=0.8.0-sp1-4.0.0-v2", package = "sp1_bls12_381", defaul
 hex = "0.4.3"
 
 [features]
-default = ["rkyv", "serde"]
 rkyv = ["dep:rkyv"]
 serde = ["dep:serde"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,9 @@ bls12_381 = { version = "=0.8.0-sp1-4.0.0-v2", package = "sp1_bls12_381", defaul
 sha2 = { version = "0.10.8", default-features = false }
 ff = { version = "0.13.0", default-features = false, features = ["derive"] }
 spin = { version = "0.9.8", default-features = false, features = ["once"] }
-serde = { version = "^1.0", default-features = false, features = ["derive"] }
+serde = { version = "^1.0", default-features = false, features = ["derive"], optional = true }
 serde_arrays = "0.2.0"
+rkyv = { version = "0.8.10", optional = true }
 
 [dev-dependencies]
 hex = "0.4.3"
@@ -34,3 +35,8 @@ bls12_381 = { version = "=0.8.0-sp1-4.0.0-v2", package = "sp1_bls12_381", defaul
     "alloc",
 ] }
 hex = "0.4.3"
+
+[features]
+default = ["rkyv", "serde"]
+rkyv = ["dep:rkyv"]
+serde = ["dep:serde"]

--- a/src/dtypes.rs
+++ b/src/dtypes.rs
@@ -3,12 +3,18 @@ use crate::kzg_proof::safe_scalar_affine_from_bytes;
 use crate::{BYTES_PER_BLOB, BYTES_PER_FIELD_ELEMENT};
 use alloc::{string::ToString, vec::Vec};
 use bls12_381::Scalar;
-use serde::{Deserialize, Serialize};
 
 macro_rules! define_bytes_type {
     ($name:ident, $size:expr) => {
-        #[derive(Debug, Clone, Serialize, Deserialize)]
-        pub struct $name(#[serde(with = "serde_arrays")] pub [u8; $size]);
+        #[cfg_attr(
+            feature = "rkyv",
+            derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
+        )]
+        #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+        #[derive(Debug, Clone)]
+        pub struct $name(
+            #[cfg_attr(feature = "serde", serde(with = "serde_arrays"))] pub [u8; $size],
+        );
 
         impl $name {
             pub fn from_slice(slice: &[u8]) -> Result<Self, KzgError> {


### PR DESCRIPTION
- Derive `rkyv` Archive, Serialize and Deserialize on `define_bytes_type`.
- Make `rkyv` and `serde` optional dependencies that are disabled by default.