### PR TITLE
fix: add selectable BLS backend features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,6 +173,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "bls12_381"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7bc6d6292be3a19e6379786dac800f551e5865a5bb51ebbe3064ab80433f403"
+dependencies = [
+ "ff 0.13.1",
+ "group 0.13.0",
+ "pairing 0.23.0",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -603,7 +616,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a575df5f985fe1cd5b2b05664ff6accfc46559032b954529fd225a2168d27b0f"
 dependencies = [
  "bitvec",
- "bls12_381",
+ "bls12_381 0.7.1",
  "ff 0.12.1",
  "group 0.12.1",
  "rand_core",
@@ -623,6 +636,7 @@ dependencies = [
 name = "kzg-rs"
 version = "0.2.8"
 dependencies = [
+ "bls12_381 0.8.0",
  "ff 0.13.1",
  "hex",
  "rkyv",
@@ -1565,7 +1579,7 @@ dependencies = [
  "ark-std",
  "bitvec",
  "blake2",
- "bls12_381",
+ "bls12_381 0.7.1",
  "byteorder",
  "cfg-if",
  "group 0.12.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,12 @@ repository = "https://github.com/succinctlabs/kzg-rs"
 [dependencies]
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
 
-bls12_381 = { version = "=0.8.0-sp1-6.0.0", package = "sp1_bls12_381", default-features = false, features = [
+bls12_381_sp1 = { version = "=0.8.0-sp1-6.0.0", package = "sp1_bls12_381", optional = true, default-features = false, features = [
+    "groups",
+    "pairings",
+    "alloc",
+] }
+bls12_381_std = { version = "0.8", package = "bls12_381", optional = true, default-features = false, features = [
     "groups",
     "pairings",
     "alloc",
@@ -31,7 +36,12 @@ serde_derive = "1.0"
 serde = { version = "^1.0", features = ["derive"] }
 
 [build-dependencies]
-bls12_381 = { version = "=0.8.0-sp1-6.0.0", package = "sp1_bls12_381", default-features = false, features = [
+bls12_381_sp1 = { version = "=0.8.0-sp1-6.0.0", package = "sp1_bls12_381", optional = true, default-features = false, features = [
+    "groups",
+    "pairings",
+    "alloc",
+] }
+bls12_381_std = { version = "0.8", package = "bls12_381", optional = true, default-features = false, features = [
     "groups",
     "pairings",
     "alloc",
@@ -39,5 +49,8 @@ bls12_381 = { version = "=0.8.0-sp1-6.0.0", package = "sp1_bls12_381", default-f
 hex = "0.4.3"
 
 [features]
+default = ["sp1"]
 rkyv = ["dep:rkyv"]
 serde = ["dep:serde"]
+sp1 = ["dep:bls12_381_sp1"]
+standard = ["dep:bls12_381_std"]

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,17 @@
 const TRUSTED_SETUP_FILE: &str = include_str!("src/trusted_setup.txt");
 
+#[cfg(all(feature = "sp1", feature = "standard"))]
+compile_error!("features `sp1` and `standard` are mutually exclusive");
+
+#[cfg(not(any(feature = "sp1", feature = "standard")))]
+compile_error!("enable exactly one BLS backend feature: `sp1` or `standard`");
+
+#[cfg(feature = "sp1")]
+pub(crate) use bls12_381_sp1 as bls12_381;
+
+#[cfg(feature = "standard")]
+pub(crate) use bls12_381_std as bls12_381;
+
 include!("src/enums.rs");
 include!("src/consts.rs");
 include!("src/pairings.rs");

--- a/src/dtypes.rs
+++ b/src/dtypes.rs
@@ -1,8 +1,8 @@
+use crate::bls12_381::Scalar;
 use crate::enums::KzgError;
 use crate::kzg_proof::safe_scalar_affine_from_bytes;
 use crate::{BYTES_PER_BLOB, BYTES_PER_FIELD_ELEMENT};
 use alloc::{string::ToString, vec::Vec};
-use bls12_381::Scalar;
 
 macro_rules! define_bytes_type {
     ($name:ident, $size:expr) => {

--- a/src/kzg_proof.rs
+++ b/src/kzg_proof.rs
@@ -9,8 +9,8 @@ use crate::{
     NUM_FIELD_ELEMENTS_PER_BLOB, RANDOM_CHALLENGE_KZG_BATCH_DOMAIN,
 };
 
+use crate::bls12_381::{G1Affine, G1Projective, G2Affine, G2Projective, Scalar};
 use alloc::{string::ToString, vec::Vec};
-use bls12_381::{G1Affine, G1Projective, G2Affine, G2Projective, Scalar};
 use ff::derive::sbb;
 use sha2::{Digest, Sha256};
 
@@ -222,6 +222,23 @@ pub fn verify_kzg_proof_impl(
     ))
 }
 
+fn msm_variable_base(points: &[G1Projective], scalars: &[Scalar]) -> G1Projective {
+    #[cfg(feature = "sp1")]
+    {
+        G1Projective::msm_variable_base(points, scalars)
+    }
+
+    #[cfg(feature = "standard")]
+    {
+        points
+            .iter()
+            .zip(scalars)
+            .fold(G1Projective::identity(), |acc, (point, scalar)| {
+                acc + (*point * *scalar)
+            })
+    }
+}
+
 pub fn validate_batched_input(
     commitment: &[G1Affine],
     proofs: &[G1Affine],
@@ -416,7 +433,7 @@ impl KzgProof {
         let proofs = proofs.iter().map(Into::into).collect::<Vec<_>>();
 
         // Compute proof linear combination
-        let proof_lincomb = G1Projective::msm_variable_base(&proofs, &r_powers);
+        let proof_lincomb = msm_variable_base(&proofs, &r_powers);
 
         // Compute c_minus_y and r_times_z
         for i in 0..n {
@@ -426,8 +443,8 @@ impl KzgProof {
         }
 
         // Compute proof_z_lincomb and c_minus_y_lincomb
-        let proof_z_lincomb = G1Projective::msm_variable_base(&proofs, &r_times_z);
-        let c_minus_y_lincomb = G1Projective::msm_variable_base(&c_minus_y, &r_powers);
+        let proof_z_lincomb = msm_variable_base(&proofs, &r_times_z);
+        let c_minus_y_lincomb = msm_variable_base(&c_minus_y, &r_powers);
 
         // Compute rhs_g1
         let rhs_g1 = c_minus_y_lincomb + proof_z_lincomb;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,18 @@
 #[macro_use]
 extern crate alloc;
 
+#[cfg(all(feature = "sp1", feature = "standard"))]
+compile_error!("features `sp1` and `standard` are mutually exclusive");
+
+#[cfg(not(any(feature = "sp1", feature = "standard")))]
+compile_error!("enable exactly one BLS backend feature: `sp1` or `standard`");
+
+#[cfg(feature = "sp1")]
+pub(crate) use bls12_381_sp1 as bls12_381;
+
+#[cfg(feature = "standard")]
+pub(crate) use bls12_381_std as bls12_381;
+
 pub mod consts;
 pub mod dtypes;
 pub mod enums;

--- a/src/pairings.rs
+++ b/src/pairings.rs
@@ -1,5 +1,5 @@
 #[allow(unused_imports)]
-use bls12_381::{multi_miller_loop, G1Affine, G2Affine, G2Prepared, Gt, Scalar};
+use crate::bls12_381::{multi_miller_loop, G1Affine, G2Affine, G2Prepared, Gt, Scalar};
 
 /// Verifies the pairing of two G1 and two G2 points are equivalent using the multi-miller loop
 pub fn pairings_verify(a1: G1Affine, a2: G2Affine, b1: G1Affine, b2: G2Affine) -> bool {

--- a/src/trusted_setup.rs
+++ b/src/trusted_setup.rs
@@ -1,7 +1,7 @@
 use crate::{enums::KzgError, NUM_G1_POINTS, NUM_ROOTS_OF_UNITY};
 
+use crate::bls12_381::{G1Affine, G2Affine, Scalar};
 use alloc::sync::Arc;
-use bls12_381::{G1Affine, G2Affine, Scalar};
 use core::{
     hash::{Hash, Hasher},
     mem::transmute,


### PR DESCRIPTION
## Why
- Allow non-SP1 zkVM targets to use kzg-rs without linking SP1-specific syscall symbols.
- Preserve the current default SP1 backend behavior for existing users.

## How
- Add mutually exclusive `sp1` and `standard` BLS backend features, with `sp1` remaining the default.
- Use ordinary `bls12_381` for the new `standard` backend and keep the existing `sp1_bls12_381` backend for SP1.
- Add a small standard-backend MSM fallback while retaining the SP1 optimized method.

## Tests
- `cargo check --no-default-features --features standard`
- `cargo check --no-default-features --features sp1`
- `cargo check`